### PR TITLE
Fix configuration window close behavior and preview display issues

### DIFF
--- a/Motivation/AgeView.swift
+++ b/Motivation/AgeView.swift
@@ -64,7 +64,11 @@ class AgeView: ScreenSaverView {
 		return label
 	}()
 
-	private var motivationLevel: MotivationLevel
+	private var motivationLevel: MotivationLevel {
+		didSet {
+			updateLabel()
+		}
+	}
 
 	private var birthday: Date? {
 		didSet {
@@ -87,6 +91,14 @@ class AgeView: ScreenSaverView {
 	override func resize(withOldSuperviewSize oldSize: NSSize) {
 		super.resize(withOldSuperviewSize: oldSize)
 		updateFont()
+	}
+	
+	// Ensure font is updated when the view is added to window
+	override func viewDidMoveToWindow() {
+		super.viewDidMoveToWindow()
+		if window != nil {
+			updateFont()
+		}
 	}
 
 

--- a/Motivation/ConfigureSheetController.swift
+++ b/Motivation/ConfigureSheetController.swift
@@ -88,7 +88,13 @@ class ConfigureSheetController: NSObject {
     }
 
     @IBAction func close(_ sender: NSButton) {
-        if let window = window {
+        guard let window = window else { return }
+        
+        // If displayed as a sheet, use endSheet to close it properly
+        if let sheetParent = window.sheetParent {
+            sheetParent.endSheet(window)
+        } else {
+            // Otherwise, close the window directly
             window.close()
         }
     }

--- a/Preview/AppDelegate.swift
+++ b/Preview/AppDelegate.swift
@@ -16,6 +16,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     lazy var screenSaverView = AgeView(frame: NSZeroRect, isPreview: false)
 
     lazy var sheetController: ConfigureSheetController = ConfigureSheetController()
+    
+    var preferencesWindow: NSWindow?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         screenSaverView.frame = (window.contentView?.bounds)!
@@ -32,9 +34,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if let window = object as? NSWindow {
+            preferencesWindow = window
             setUp(preferencesWindow: window)
         }
 
+    }
+    
+    @IBAction func showPreferences(_ sender: Any?) {
+        guard let preferencesWindow = preferencesWindow else { return }
+        preferencesWindow.makeKeyAndOrderFront(sender)
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/Preview/MainMenu.xib
+++ b/Preview/MainMenu.xib
@@ -32,7 +32,11 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
+                                <connections>
+                                    <action selector="showPreferences:" target="Voe-Tx-rLC" id="pref-action-id"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
                             <menuItem title="Services" id="NMo-om-nkz">
                                 <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
## Changes

This PR fixes several issues with the configuration window and preview mode:

### Fixed Issues

1. **Configuration window not closing properly in System Preferences**
   - The OK button now correctly closes the sheet window using `endSheet()` when displayed in System Preferences
   - Falls back to `close()` for standalone window mode

2. **No way to reopen configuration window in Preview app**
   - Added `showPreferences:` action in AppDelegate
   - Connected Preferences menu item (Cmd+,) to reopen the configuration window

3. **Font size display issue on Preview app startup**
   - Added `viewDidMoveToWindow()` to ensure font size is calculated after the view has proper bounds

4. **Motivation level changes not taking effect immediately**
   - Added `didSet` observer to `motivationLevel` property to trigger label update

### Files Changed

- `Motivation/ConfigureSheetController.swift`
- `Preview/AppDelegate.swift`
- `Preview/MainMenu.xib`
- `Motivation/AgeView.swift`

### Testing

Tested on macOS 15.7.3 with both:
- System Preferences screen saver settings
- Preview.app for development

All issues are resolved and working as expected.